### PR TITLE
Axios config pass through and request cancellation config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 test/
 yarn.lock
 package-lock.json
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# Deprecation notice (08-04-2021)
+
+This repo was forked under the dashhudson org for maintenance purposes as the original project is dead. We won't be
+responding to outside requests for changes.
+
 # vuex-rest-api
 
 [![](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/vuejs/awesome-vue)

--- a/dist/Resource.d.ts
+++ b/dist/Resource.d.ts
@@ -1,8 +1,10 @@
 import { AxiosInstance } from "axios";
 export interface ResourceAction {
     requestFn: Function;
+    autoCancel: Boolean;
     beforeRequest: Function;
     onSuccess: Function;
+    onCancel: Function;
     onError: Function;
     property: string;
     dispatchString: string;
@@ -16,8 +18,10 @@ export interface ShorthandResourceActionOptions {
     action: string;
     property?: string;
     path: Function | string;
+    autoCancel?: Boolean;
     beforeRequest?: Function;
     onSuccess?: Function;
+    onCancel?: Function;
     onError?: Function;
     requestConfig?: Object;
     queryParams?: Boolean;

--- a/dist/Resource.d.ts
+++ b/dist/Resource.d.ts
@@ -1,10 +1,8 @@
 import { AxiosInstance } from "axios";
 export interface ResourceAction {
     requestFn: Function;
-    autoCancel: Boolean;
     beforeRequest: Function;
     onSuccess: Function;
-    onCancel: Function;
     onError: Function;
     property: string;
     dispatchString: string;
@@ -18,10 +16,8 @@ export interface ShorthandResourceActionOptions {
     action: string;
     property?: string;
     path: Function | string;
-    autoCancel?: Boolean;
     beforeRequest?: Function;
     onSuccess?: Function;
-    onCancel?: Function;
     onError?: Function;
     requestConfig?: Object;
     queryParams?: Boolean;

--- a/dist/Resource.js
+++ b/dist/Resource.js
@@ -31,9 +31,17 @@ var Resource = /** @class */ (function () {
             urlFn = function () { return options.path; };
         }
         this.actions[options.action] = {
-            requestFn: function (params, data) {
-                if (params === void 0) { params = {}; }
-                if (data === void 0) { data = {}; }
+            requestFn: function (requestConfig) {
+                var tmpRequestConfig = Object.assign({}, requestConfig, options.requestConfig);
+                var params = tmpRequestConfig.params;
+                if (headersFn) {
+                    if (tmpRequestConfig["headers"]) {
+                        Object.assign(tmpRequestConfig["headers"], headersFn(params));
+                    }
+                    else {
+                        tmpRequestConfig["headers"] = headersFn(params);
+                    }
+                }
                 var queryParams;
                 // use action specific queryParams if set
                 if (options.queryParams !== undefined) {
@@ -43,33 +51,26 @@ var Resource = /** @class */ (function () {
                 else {
                     queryParams = _this.queryParams;
                 }
-                var requestConfig = Object.assign({}, options.requestConfig);
-                var paramsSerializer = options.requestConfig["paramsSerializer"] !== undefined ||
-                    _this.axios.defaults.paramsSerializer !== undefined;
-                if (queryParams || paramsSerializer) {
-                    requestConfig["params"] = params;
+                // If the queryParams config is disabled omit params in fullRequestConfig. This is to keep changes around
+                // passing in a complete AxiosRequestConfig backwards compatible with previous versions of the library where
+                // the ActionParams partial was used.
+                if (!queryParams) {
+                    tmpRequestConfig["params"] = {};
                 }
-                if (headersFn) {
-                    if (requestConfig["headers"]) {
-                        Object.assign(requestConfig["headers"], headersFn(params));
-                    }
-                    else {
-                        requestConfig["headers"] = headersFn(params);
-                    }
-                }
-                // This is assignment is made to respect the priority of the base URL, url, method and data.
+                // This assignment is made to respect the priority of the base URL, url, method.
                 // It is as following: baseURL > axios instance base URL > request config base URL
                 var fullRequestConfig = Object.assign({
                     method: options.method,
                     url: urlFn(params),
                     baseURL: _this.normalizedBaseURL,
-                    data: data
-                }, requestConfig);
+                }, tmpRequestConfig);
                 return _this.axios.request(fullRequestConfig);
             },
             property: options.property,
+            autoCancel: options.autoCancel,
             beforeRequest: options.beforeRequest,
             onSuccess: options.onSuccess,
+            onCancel: options.onCancel,
             onError: options.onError,
             dispatchString: this.getDispatchString(options.action),
             commitString: this.getCommitString(options.action),

--- a/dist/Store.js
+++ b/dist/Store.js
@@ -37,13 +37,11 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.createStore = void 0;
-var axios_1 = require("axios");
 var cloneDeep = require("lodash.clonedeep");
 var StoreCreator = /** @class */ (function () {
     function StoreCreator(resource, options) {
         this.successSuffix = "SUCCEEDED";
         this.errorSuffix = "FAILED";
-        this.resource = resource;
         this.resource = resource;
         this.options = Object.assign({
             createStateFn: false,
@@ -63,8 +61,7 @@ var StoreCreator = /** @class */ (function () {
         var resourceState = cloneDeep(this.resource.state);
         var state = Object.assign({
             pending: {},
-            error: {},
-            source: {},
+            error: {}
         }, resourceState);
         var actions = this.resource.actions;
         Object.keys(actions).forEach(function (action) {
@@ -79,7 +76,6 @@ var StoreCreator = /** @class */ (function () {
             }
             state["pending"][property] = false;
             state["error"][property] = null;
-            state["source"][property] = null;
         });
         return state;
     };
@@ -89,8 +85,7 @@ var StoreCreator = /** @class */ (function () {
             var resourceState = cloneDeep(_this.resource.state);
             var state = Object.assign({
                 pending: {},
-                error: {},
-                source: {},
+                error: {}
             }, resourceState);
             var actions = _this.resource.actions;
             Object.keys(actions).forEach(function (action) {
@@ -105,7 +100,6 @@ var StoreCreator = /** @class */ (function () {
                 }
                 state["pending"][property] = false;
                 state["error"][property] = null;
-                state["source"][property] = null;
             });
             return state;
         };
@@ -118,64 +112,37 @@ var StoreCreator = /** @class */ (function () {
         var mutations = {};
         var actions = this.resource.actions;
         Object.keys(actions).forEach(function (action) {
-            var _a = actions[action], property = _a.property, commitString = _a.commitString, autoCancel = _a.autoCancel, beforeRequest = _a.beforeRequest, onSuccess = _a.onSuccess, onCancel = _a.onCancel, onError = _a.onError, axios = _a.axios;
-            mutations["" + commitString] = function (state, requestConfig) {
+            var _a = actions[action], property = _a.property, commitString = _a.commitString, beforeRequest = _a.beforeRequest, onSuccess = _a.onSuccess, onError = _a.onError, axios = _a.axios;
+            mutations["" + commitString] = function (state, actionParams) {
                 if (property !== null) {
                     state.pending[property] = true;
                     state.error[property] = null;
-                    // If autoCancel is enabled and this property maps to a source state, cancel the current pending request.
-                    if (autoCancel && state.source[property]) {
-                        state.source[property].cancel();
-                    }
-                    // If the request config doesn't contain a cancel token, set one in state for convenience. We'll let the user
-                    // provided token take precedence here though in case it's needed for a special controlled flow.
-                    if (!requestConfig.cancelToken) {
-                        var source = StoreCreator.CANCEL_TOKEN_PROVIDER.source();
-                        state.source[property] = source;
-                        requestConfig["cancelToken"] = source.token;
-                    }
                 }
                 if (beforeRequest) {
-                    beforeRequest(state, requestConfig);
+                    beforeRequest(state, actionParams);
                 }
             };
             mutations[commitString + "_" + _this.successSuffix] = function (state, _a) {
-                var payload = _a.payload, requestConfig = _a.requestConfig;
+                var payload = _a.payload, actionParams = _a.actionParams;
                 if (property !== null) {
                     state.pending[property] = false;
                     state.error[property] = null;
-                    state.source[property] = null;
                 }
                 if (onSuccess) {
-                    onSuccess(state, payload, axios, requestConfig);
+                    onSuccess(state, payload, axios, actionParams);
                 }
                 else if (property !== null) {
                     state[property] = payload.data;
                 }
             };
             mutations[commitString + "_" + _this.errorSuffix] = function (state, _a) {
-                var payload = _a.payload, requestConfig = _a.requestConfig;
-                // Call onCancel if a cancellation error occurs, this can be helpful to let developers differentiate between
-                // a normal error path and something separate for cancellation. It will also be called if autoCancel is enabled
-                // where onError will not.
-                var isCancellationErr = axios_1.default.isCancel(payload);
-                if (typeof onCancel === 'function' && isCancellationErr) {
-                    onCancel(state, payload, axios, requestConfig);
-                }
-                // The logic here is as follows: if either autoCancel is disabled or the error was not a cancellation error,
-                // we'll prevent error handling and clean up. We'll assume that for most cases where autoCancel is useful,
-                // we'll want to effectively suspend the lifetime of the pending state until a retry occurs.
-                var shouldHandleErr = !autoCancel || !isCancellationErr;
-                if (!shouldHandleErr) {
-                    return;
-                }
+                var payload = _a.payload, actionParams = _a.actionParams;
                 if (property !== null) {
                     state.pending[property] = false;
                     state.error[property] = payload;
-                    state.source[property] = null;
                 }
                 if (onError) {
-                    onError(state, payload, axios, requestConfig);
+                    onError(state, payload, axios, actionParams);
                 }
                 else if (property !== null) {
                     // sets property to it's default value in case of an error
@@ -191,28 +158,28 @@ var StoreCreator = /** @class */ (function () {
         var actions = this.resource.actions;
         Object.keys(actions).forEach(function (action) {
             var _a = actions[action], dispatchString = _a.dispatchString, commitString = _a.commitString, requestFn = _a.requestFn;
-            storeActions[dispatchString] = function (_a, requestConfig) {
+            storeActions[dispatchString] = function (_a, actionParams) {
                 var commit = _a.commit;
-                if (requestConfig === void 0) { requestConfig = cloneDeep(StoreCreator.DEFAULT_REQUEST_CONFIG); }
+                if (actionParams === void 0) { actionParams = { params: {}, data: {} }; }
                 return __awaiter(_this, void 0, void 0, function () {
                     var _this = this;
                     return __generator(this, function (_b) {
-                        if (!requestConfig.params)
-                            requestConfig.params = {};
-                        if (!requestConfig.data)
-                            requestConfig.data = {};
-                        commit(commitString, requestConfig);
-                        return [2 /*return*/, requestFn(requestConfig)
+                        if (!actionParams.params)
+                            actionParams.params = {};
+                        if (!actionParams.data)
+                            actionParams.data = {};
+                        commit(commitString, actionParams);
+                        return [2 /*return*/, requestFn(actionParams.params, actionParams.data)
                                 .then(function (response) {
                                 commit(commitString + "_" + _this.successSuffix, {
                                     payload: response,
-                                    requestConfig: requestConfig
+                                    actionParams: actionParams
                                 });
                                 return Promise.resolve(response);
                             }, function (error) {
                                 commit(commitString + "_" + _this.errorSuffix, {
                                     payload: error,
-                                    requestConfig: requestConfig
+                                    actionParams: actionParams
                                 });
                                 return Promise.reject(error);
                             })];
@@ -231,8 +198,6 @@ var StoreCreator = /** @class */ (function () {
             actions: this.createActions()
         };
     };
-    StoreCreator.CANCEL_TOKEN_PROVIDER = axios_1.default.CancelToken;
-    StoreCreator.DEFAULT_REQUEST_CONFIG = { params: {}, data: {} };
     return StoreCreator;
 }());
 function createStore(resource, options) {

--- a/dist/Store.js
+++ b/dist/Store.js
@@ -37,11 +37,13 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.createStore = void 0;
+var axios_1 = require("axios");
 var cloneDeep = require("lodash.clonedeep");
 var StoreCreator = /** @class */ (function () {
     function StoreCreator(resource, options) {
         this.successSuffix = "SUCCEEDED";
         this.errorSuffix = "FAILED";
+        this.resource = resource;
         this.resource = resource;
         this.options = Object.assign({
             createStateFn: false,
@@ -61,7 +63,8 @@ var StoreCreator = /** @class */ (function () {
         var resourceState = cloneDeep(this.resource.state);
         var state = Object.assign({
             pending: {},
-            error: {}
+            error: {},
+            source: {},
         }, resourceState);
         var actions = this.resource.actions;
         Object.keys(actions).forEach(function (action) {
@@ -76,6 +79,7 @@ var StoreCreator = /** @class */ (function () {
             }
             state["pending"][property] = false;
             state["error"][property] = null;
+            state["source"][property] = null;
         });
         return state;
     };
@@ -85,7 +89,8 @@ var StoreCreator = /** @class */ (function () {
             var resourceState = cloneDeep(_this.resource.state);
             var state = Object.assign({
                 pending: {},
-                error: {}
+                error: {},
+                source: {},
             }, resourceState);
             var actions = _this.resource.actions;
             Object.keys(actions).forEach(function (action) {
@@ -100,6 +105,7 @@ var StoreCreator = /** @class */ (function () {
                 }
                 state["pending"][property] = false;
                 state["error"][property] = null;
+                state["source"][property] = null;
             });
             return state;
         };
@@ -112,37 +118,64 @@ var StoreCreator = /** @class */ (function () {
         var mutations = {};
         var actions = this.resource.actions;
         Object.keys(actions).forEach(function (action) {
-            var _a = actions[action], property = _a.property, commitString = _a.commitString, beforeRequest = _a.beforeRequest, onSuccess = _a.onSuccess, onError = _a.onError, axios = _a.axios;
-            mutations["" + commitString] = function (state, actionParams) {
+            var _a = actions[action], property = _a.property, commitString = _a.commitString, autoCancel = _a.autoCancel, beforeRequest = _a.beforeRequest, onSuccess = _a.onSuccess, onCancel = _a.onCancel, onError = _a.onError, axios = _a.axios;
+            mutations["" + commitString] = function (state, requestConfig) {
                 if (property !== null) {
                     state.pending[property] = true;
                     state.error[property] = null;
+                    // If autoCancel is enabled and this property maps to a source state, cancel the current pending request.
+                    if (autoCancel && state.source[property]) {
+                        state.source[property].cancel();
+                    }
+                    // If the request config doesn't contain a cancel token, set one in state for convenience. We'll let the user
+                    // provided token take precedence here though in case it's needed for a special controlled flow.
+                    if (!requestConfig.cancelToken) {
+                        var source = StoreCreator.CANCEL_TOKEN_PROVIDER.source();
+                        state.source[property] = source;
+                        requestConfig["cancelToken"] = source.token;
+                    }
                 }
                 if (beforeRequest) {
-                    beforeRequest(state, actionParams);
+                    beforeRequest(state, requestConfig);
                 }
             };
             mutations[commitString + "_" + _this.successSuffix] = function (state, _a) {
-                var payload = _a.payload, actionParams = _a.actionParams;
+                var payload = _a.payload, requestConfig = _a.requestConfig;
                 if (property !== null) {
                     state.pending[property] = false;
                     state.error[property] = null;
+                    state.source[property] = null;
                 }
                 if (onSuccess) {
-                    onSuccess(state, payload, axios, actionParams);
+                    onSuccess(state, payload, axios, requestConfig);
                 }
                 else if (property !== null) {
                     state[property] = payload.data;
                 }
             };
             mutations[commitString + "_" + _this.errorSuffix] = function (state, _a) {
-                var payload = _a.payload, actionParams = _a.actionParams;
+                var payload = _a.payload, requestConfig = _a.requestConfig;
+                // Call onCancel if a cancellation error occurs, this can be helpful to let developers differentiate between
+                // a normal error path and something separate for cancellation. It will also be called if autoCancel is enabled
+                // where onError will not.
+                var isCancellationErr = axios_1.default.isCancel(payload);
+                if (typeof onCancel === 'function' && isCancellationErr) {
+                    onCancel(state, payload, axios, requestConfig);
+                }
+                // The logic here is as follows: if either autoCancel is disabled or the error was not a cancellation error,
+                // we'll prevent error handling and clean up. We'll assume that for most cases where autoCancel is useful,
+                // we'll want to effectively suspend the lifetime of the pending state until a retry occurs.
+                var shouldHandleErr = !autoCancel || !isCancellationErr;
+                if (!shouldHandleErr) {
+                    return;
+                }
                 if (property !== null) {
                     state.pending[property] = false;
                     state.error[property] = payload;
+                    state.source[property] = null;
                 }
                 if (onError) {
-                    onError(state, payload, axios, actionParams);
+                    onError(state, payload, axios, requestConfig);
                 }
                 else if (property !== null) {
                     // sets property to it's default value in case of an error
@@ -158,28 +191,28 @@ var StoreCreator = /** @class */ (function () {
         var actions = this.resource.actions;
         Object.keys(actions).forEach(function (action) {
             var _a = actions[action], dispatchString = _a.dispatchString, commitString = _a.commitString, requestFn = _a.requestFn;
-            storeActions[dispatchString] = function (_a, actionParams) {
+            storeActions[dispatchString] = function (_a, requestConfig) {
                 var commit = _a.commit;
-                if (actionParams === void 0) { actionParams = { params: {}, data: {} }; }
+                if (requestConfig === void 0) { requestConfig = cloneDeep(StoreCreator.DEFAULT_REQUEST_CONFIG); }
                 return __awaiter(_this, void 0, void 0, function () {
                     var _this = this;
                     return __generator(this, function (_b) {
-                        if (!actionParams.params)
-                            actionParams.params = {};
-                        if (!actionParams.data)
-                            actionParams.data = {};
-                        commit(commitString, actionParams);
-                        return [2 /*return*/, requestFn(actionParams.params, actionParams.data)
+                        if (!requestConfig.params)
+                            requestConfig.params = {};
+                        if (!requestConfig.data)
+                            requestConfig.data = {};
+                        commit(commitString, requestConfig);
+                        return [2 /*return*/, requestFn(requestConfig)
                                 .then(function (response) {
                                 commit(commitString + "_" + _this.successSuffix, {
                                     payload: response,
-                                    actionParams: actionParams
+                                    requestConfig: requestConfig
                                 });
                                 return Promise.resolve(response);
                             }, function (error) {
                                 commit(commitString + "_" + _this.errorSuffix, {
                                     payload: error,
-                                    actionParams: actionParams
+                                    requestConfig: requestConfig
                                 });
                                 return Promise.reject(error);
                             })];
@@ -198,6 +231,8 @@ var StoreCreator = /** @class */ (function () {
             actions: this.createActions()
         };
     };
+    StoreCreator.CANCEL_TOKEN_PROVIDER = axios_1.default.CancelToken;
+    StoreCreator.DEFAULT_REQUEST_CONFIG = { params: {}, data: {} };
     return StoreCreator;
 }());
 function createStore(resource, options) {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lodash.clonedeep": "^4.5"
   },
   "peerDependencies": {
-    "axios": "^0.19"
+    "axios": "^0.21.1"
   },
   "scripts": {
     "build": "tsc -p ."

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -165,7 +165,6 @@ class StoreCreator {
         }
       }
       mutations[`${commitString}_${this.errorSuffix}`] = (state, { payload, requestConfig, isCancellationErr }) => {
-        // Clean up store if the err should be handled
         if (property !== null) {
           state.pending[property] = false
           state.error[property] = payload
@@ -173,7 +172,6 @@ class StoreCreator {
           state[property] = defaultState[property]
         }
 
-        // Use the appropriate error callback if the error should handled / is a function
         if (!isCancellationErr && onError) {
           onError(state, payload, axios, requestConfig)
         } else if (isCancellationErr && onCancel) {

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -146,7 +146,7 @@ class StoreCreator {
           }
         }
 
-        if (typeof beforeRequest === 'function') {
+        if (beforeRequest) {
           beforeRequest(state, requestConfig)
         }
       }
@@ -158,7 +158,7 @@ class StoreCreator {
           state.source[property] = null
         }
 
-        if (typeof onSuccess === 'function') {
+        if (onSuccess) {
           onSuccess(state, payload, axios, requestConfig)
         } else if (property !== null) {
           state[property] = payload.data
@@ -174,9 +174,9 @@ class StoreCreator {
         }
 
         // Use the appropriate error callback if the error should handled / is a function
-        if (!isCancellationErr && typeof onError === 'function') {
+        if (!isCancellationErr && onError) {
           onError(state, payload, axios, requestConfig)
-        } else if (isCancellationErr && typeof onCancel === 'function') {
+        } else if (isCancellationErr && onCancel) {
           onCancel(state, payload, axios, requestConfig)
         }
       }

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -1,4 +1,5 @@
-import Resource, { ResourceActionMap } from "./Resource"
+import Resource from "./Resource"
+import axiosStatic, { CancelTokenStatic, AxiosRequestConfig } from "axios"
 import * as cloneDeep from "lodash.clonedeep"
 
 export interface Store {
@@ -22,12 +23,10 @@ export interface MutationMap {
   [action: string]: Function
 }
 
-interface ActionParamsBody {
-  params: object
-  data: object
-}
-
 class StoreCreator {
+  private static readonly CANCEL_TOKEN_PROVIDER: CancelTokenStatic = axiosStatic.CancelToken
+  private static readonly DEFAULT_REQUEST_CONFIG: AxiosRequestConfig = { params: {}, data: {} }
+
   private resource: Resource
   private options: StoreOptions
   private successSuffix: string = "SUCCEEDED"
@@ -35,6 +34,7 @@ class StoreCreator {
   public store: Store
 
   constructor(resource: Resource, options: StoreOptions) {
+    this.resource = resource
     this.resource = resource
     this.options = Object.assign({
       createStateFn: false,
@@ -57,7 +57,8 @@ class StoreCreator {
 
     const state: object = Object.assign({
       pending: {},
-      error: {}
+      error: {},
+      source: {},
     }, resourceState)
 
     const actions = this.resource.actions
@@ -76,6 +77,7 @@ class StoreCreator {
 
       state["pending"][property] = false
       state["error"][property] = null
+      state["source"][property] = null
     })
 
     return state
@@ -87,7 +89,8 @@ class StoreCreator {
 
       const state: object = Object.assign({
         pending: {},
-        error: {}
+        error: {},
+        source: {},
       }, resourceState)
 
       const actions = this.resource.actions
@@ -106,6 +109,7 @@ class StoreCreator {
 
         state["pending"][property] = false
         state["error"][property] = null
+        state["source"][property] = null
       })
 
       return state
@@ -121,43 +125,72 @@ class StoreCreator {
 
     const actions = this.resource.actions
     Object.keys(actions).forEach((action) => {
-      const { property, commitString, beforeRequest, onSuccess, onError, axios } = actions[action]
+      const { property, commitString, autoCancel, beforeRequest, onSuccess, onCancel, onError, axios } = actions[action]
 
-      mutations[`${commitString}`] = (state, actionParams) => {
+      mutations[`${commitString}`] = (state, requestConfig) => {
 
         if (property !== null) {
           state.pending[property] = true
           state.error[property] = null
+
+          // If autoCancel is enabled and this property maps to a source state, cancel the current pending request.
+          if (autoCancel && state.source[property]) {
+            state.source[property].cancel()
+          }
+          // If the request config doesn't contain a cancel token, set one in state for convenience. We'll let the user
+          // provided token take precedence here though in case it's needed for a special controlled flow.
+          if (!requestConfig.cancelToken) {
+            const source = StoreCreator.CANCEL_TOKEN_PROVIDER.source()
+            state.source[property] = source
+            requestConfig["cancelToken"] = source.token
+          }
         }
 
         if (beforeRequest) {
-          beforeRequest(state, actionParams)
+          beforeRequest(state, requestConfig)
         }
       }
-      mutations[`${commitString}_${this.successSuffix}`] = (state, { payload, actionParams }) => {
+      mutations[`${commitString}_${this.successSuffix}`] = (state, { payload, requestConfig }) => {
 
         if (property !== null) {
           state.pending[property] = false
           state.error[property] = null
+          state.source[property] = null
         }
 
         if (onSuccess) {
-          onSuccess(state, payload, axios, actionParams)
+          onSuccess(state, payload, axios, requestConfig)
         } else if (property !== null) {
           state[property] = payload.data
         }
       }
-      mutations[`${commitString}_${this.errorSuffix}`] = (state, { payload, actionParams }) => {
+      mutations[`${commitString}_${this.errorSuffix}`] = (state, { payload, requestConfig }) => {
+
+        // Call onCancel if a cancellation error occurs, this can be helpful to let developers differentiate between
+        // a normal error path and something separate for cancellation. It will also be called if autoCancel is enabled
+        // where onError will not.
+        const isCancellationErr = axiosStatic.isCancel(payload)
+        if (typeof onCancel === 'function' && isCancellationErr) {
+          onCancel(state, payload, axios, requestConfig)
+        }
+
+        // The logic here is as follows: if either autoCancel is disabled or the error was not a cancellation error,
+        // we'll prevent error handling and clean up. We'll assume that for most cases where autoCancel is useful,
+        // we'll want to effectively suspend the lifetime of the pending state until a retry occurs.
+        const shouldHandleErr = !autoCancel || !isCancellationErr
+        if (!shouldHandleErr) {
+          return;
+        }
 
         if (property !== null) {
           state.pending[property] = false
           state.error[property] = payload
+          state.source[property] = null
         }
 
         if (onError) {
-          onError(state, payload, axios, actionParams)
+          onError(state, payload, axios, requestConfig)
         } else if (property !== null) {
-
           // sets property to it's default value in case of an error
           state[property] = defaultState[property]
         }
@@ -174,22 +207,22 @@ class StoreCreator {
     Object.keys(actions).forEach((action) => {
       const { dispatchString, commitString, requestFn } = actions[action]
 
-      storeActions[dispatchString] = async ({ commit }, actionParams: ActionParamsBody = { params: {}, data: {} }) => {
-        if (!actionParams.params)
-          actionParams.params = {}
-        if (!actionParams.data)
-          actionParams.data = {}
+      storeActions[dispatchString] = async ({ commit }, requestConfig = cloneDeep(StoreCreator.DEFAULT_REQUEST_CONFIG)) => {
+        if (!requestConfig.params)
+          requestConfig.params = {}
+        if (!requestConfig.data)
+          requestConfig.data = {}
 
-        commit(commitString, actionParams)
-        return requestFn(actionParams.params, actionParams.data)
+        commit(commitString, requestConfig)
+        return requestFn(requestConfig)
           .then((response) => {
             commit(`${commitString}_${this.successSuffix}`, {
-              payload: response, actionParams
+              payload: response, requestConfig
             })
             return Promise.resolve(response)
           }, (error) => {
             commit(`${commitString}_${this.errorSuffix}`, {
-              payload: error, actionParams
+              payload: error, requestConfig
             })
             return Promise.reject(error)
           })

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -190,7 +190,7 @@ class StoreCreator {
 
     const actions = this.resource.actions
     Object.keys(actions).forEach((action) => {
-      const { dispatchString, commitString, requestFn, autoCancel, onCancel } = actions[action]
+      const { dispatchString, commitString, requestFn, autoCancel } = actions[action]
 
       storeActions[dispatchString] = async ({ commit }, requestConfig = cloneDeep(StoreCreator.DEFAULT_REQUEST_CONFIG)) => {
         if (!requestConfig.params)

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -169,13 +169,14 @@ class StoreCreator {
           state.pending[property] = false
           state.error[property] = payload
           state.source[property] = null
-          state[property] = defaultState[property]
         }
 
         if (!isCancellationErr && onError) {
           onError(state, payload, axios, requestConfig)
         } else if (isCancellationErr && onCancel) {
           onCancel(state, payload, axios, requestConfig)
+        } else if (property !== null) {
+          state[property] = defaultState[property]
         }
       }
     })

--- a/tests/build/dev-server.js
+++ b/tests/build/dev-server.js
@@ -10,6 +10,7 @@ var path = require('path')
 var express = require('express')
 var webpack = require('webpack')
 var proxyMiddleware = require('http-proxy-middleware')
+var testRoutes = require('./test-routes')
 var webpackConfig = process.env.NODE_ENV === 'testing'
   ? require('./webpack.prod.conf')
   : require('./webpack.dev.conf')
@@ -49,6 +50,9 @@ Object.keys(proxyTable).forEach(function (context) {
   }
   app.use(proxyMiddleware(options.filter || context, options))
 })
+
+// Add test API routes
+testRoutes.setupTestRoutes(app)
 
 // handle fallback for HTML5 history API
 app.use(require('connect-history-api-fallback')())

--- a/tests/build/test-routes.js
+++ b/tests/build/test-routes.js
@@ -1,0 +1,14 @@
+var config = require('../config')
+
+// Adds routing for test environment(s)
+exports.setupTestRoutes = function (app) {
+  app.get('/api/cancel/long-running', (req, res) => {
+    setTimeout(() => {
+      res.json([
+        {foo: 'bar1'},
+        {foo: 'bar2'},
+        {foo: 'bar3'},
+      ]);
+    }, config.dev.longRunningTaskTimeout);
+  })
+}

--- a/tests/config/index.js
+++ b/tests/config/index.js
@@ -33,6 +33,7 @@ module.exports = {
     // (https://github.com/webpack/css-loader#sourcemaps)
     // In our experience, they generally work as expected,
     // just be aware of this issue when enabling this option.
-    cssSourceMap: false
+    cssSourceMap: false,
+    longRunningTaskTimeout: 5000
   }
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"
   },
   "dependencies": {
-    "axios": "^0.19.1",
+    "axios": "^0.21.1",
     "vue": "^2.2.6",
     "vue-router": "^2.3.1",
     "vuex": "^2.3.1"

--- a/tests/src/components/CancelTest.vue
+++ b/tests/src/components/CancelTest.vue
@@ -80,11 +80,7 @@ export default {
       return (pending) ? 'loading...' : JSON.stringify(items, null, 4)
     },
     async doGetItemsAutoCancel() {
-      try {
-        await this.getItemsLongRunningAutoCancel({ params: { foo: 'getAuto' } })
-      } catch (e) {
-        console.error(e)
-      }
+      this.getItemsLongRunningAutoCancel({ params: { foo: 'getAuto' } })
     },
     doCancelGetItemsManual() {
       if (this.cancel.source.itemsManual) {

--- a/tests/src/components/CancelTest.vue
+++ b/tests/src/components/CancelTest.vue
@@ -1,0 +1,151 @@
+<template>
+  <div>
+    <h1>Cancellation Tests</h1>
+
+    <div class="test-container">
+      <h3>Auto Cancellation</h3>
+      <p>
+        Automatically cancel a pending request for an action and suspend the pending state until the next request is
+        fulfilled or if there's a non-cancellation error. Press the fetch button below repeatedly and check the network
+        tab in your dev tools for a detailed look at what's going on.
+      </p>
+      <code class="cancel-data">{{ autoItemsStr }}</code>
+      <button @click="doGetItemsAutoCancel">Fetch Items</button>
+    </div>
+
+    <div class="test-container">
+      <h3>Manual Cancellation - Using store</h3>
+      <p>
+        Cancel sources can also be accessed in the store and used manually.
+      </p>
+      <code class="cancel-data">{{ manualItemsStr }}</code>
+      <button @click="manualButtonClick">{{ manualButtonCTA }}</button>
+    </div>
+
+    <div class="test-container">
+      <h3>Manual Cancellation - Controlled</h3>
+      <p>
+        If you don't want to use either of the above flows, you can pass in a cancel token with the request config for
+        a controlled approach.
+      </p>
+      <code class="cancel-data">{{ controlledItemsStr }}</code>
+      <button @click="controlledButtonClick">{{ controlledButtonCTA }}</button>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapState, mapActions } from 'vuex'
+import axios from 'axios'
+
+const CancelToken = axios.CancelToken
+
+export default {
+  data() {
+    return {
+      controlledSource: null
+    }
+  },
+  computed: {
+    ...mapState({
+      cancel: state => state.cancel
+    }),
+    autoItemsStr() {
+      return this.formatItemsStr(this.cancel.pending.itemsAuto, this.cancel.itemsAuto)
+    },
+    manualItemsStr() {
+      return this.formatItemsStr(this.cancel.pending.itemsManual, this.cancel.itemsManual)
+    },
+    controlledItemsStr() {
+      return this.formatItemsStr(this.cancel.pending.itemsControlled, this.cancel.itemsControlled)
+    },
+    manualButtonCTA() {
+      return this.formatDynamicCTA(this.cancel.pending.itemsManual)
+    },
+    manualButtonClick() {
+      return (this.cancel.pending.itemsManual) ? this.doCancelGetItemsManual : this.getGetItemsManual
+    },
+    controlledButtonCTA() {
+      return this.formatDynamicCTA(this.cancel.pending.itemsControlled)
+    },
+    controlledButtonClick() {
+      return (this.cancel.pending.itemsControlled) ? this.doCancelGetItemsControlled : this.doGetItemsControlled
+    }
+  },
+  methods: {
+    formatDynamicCTA(pending) {
+      return (pending) ? 'Cancel Request' : 'Fetch Items'
+    },
+    formatItemsStr(pending, items) {
+      return (pending) ? 'loading...' : JSON.stringify(items, null, 4)
+    },
+    async doGetItemsAutoCancel() {
+      try {
+        await this.getItemsLongRunningAutoCancel({ params: { foo: 'getAuto' } })
+      } catch (e) {
+        console.error(e)
+      }
+    },
+    doCancelGetItemsManual() {
+      if (this.cancel.source.itemsManual) {
+        this.cancel.source.itemsManual.cancel()
+      }
+    },
+    async getGetItemsManual() {
+      try {
+        await this.getItemsLongRunningManual({ params: { foo: 'getManual' } })
+      } catch (e) {
+        console.error(e)
+      }
+    },
+    doCancelGetItemsControlled() {
+      if (this.controlledSource) {
+        this.controlledSource.cancel()
+      }
+    },
+    async doGetItemsControlled() {
+      this.controlledSource = CancelToken.source()
+      try {
+        await this.getItemsLongRunningControlled({
+          params: { foo: 'getControlled' },
+          cancelToken: this.controlledSource.token
+        })
+      } catch (e) {
+        console.error(e)
+      }
+    },
+    ...mapActions([
+      "getItemsLongRunningAutoCancel",
+      "getItemsLongRunningManual",
+      "getItemsLongRunningControlled"
+    ])
+  }
+}
+</script>
+
+<style>
+.test-container {
+  max-width: 40rem;
+  margin: 2rem auto 3rem auto;
+}
+
+.test-container:first-of-type {
+  margin-top: 4rem;
+}
+
+.test-container > h3 {
+  margin-bottom: 0.2rem;
+}
+
+.test-container > p {
+  margin-top: 0;
+}
+
+.cancel-data {
+  background: dimgrey;
+  color: white;
+  padding: 1rem;
+  display: block;
+  margin-bottom: 1rem;
+}
+</style>

--- a/tests/src/router/index.js
+++ b/tests/src/router/index.js
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import Router from 'vue-router'
 import VuexTest from "@/components/VuexTest"
 import ModuleTest from "@/components/ModuleTest"
+import CancelTest from "@/components/CancelTest"
 
 Vue.use(Router)
 
@@ -14,6 +15,10 @@ const router = new Router({
     {
       path: "/module",
       component: ModuleTest
+    },
+    {
+      path: "/cancel",
+      component: CancelTest
     },
     {
       path: "*",

--- a/tests/src/stores/cancel.js
+++ b/tests/src/stores/cancel.js
@@ -13,10 +13,7 @@ const cancel = new Vapi({
     autoCancel: true,
     action: "getItemsLongRunningAutoCancel",
     property: "itemsAuto",
-    path: "/long-running",
-    onCancel: (state, payload) => {
-      console.info("auto cancellation", state, payload)
-    }
+    path: "/long-running"
   })
   .get({
     action: "getItemsLongRunningManual",

--- a/tests/src/stores/cancel.js
+++ b/tests/src/stores/cancel.js
@@ -1,0 +1,39 @@
+import Vapi from "vuex-rest-api"
+
+const cancel = new Vapi({
+  baseURL: "/api/cancel",
+  queryParams: true,
+  state: {
+    itemsAuto: [],
+    itemsManual: [],
+    itemsControlled: []
+  }
+})
+  .get({
+    autoCancel: true,
+    action: "getItemsLongRunningAutoCancel",
+    property: "itemsAuto",
+    path: "/long-running",
+    onCancel: (state, payload) => {
+      console.info("auto cancellation", state, payload)
+    }
+  })
+  .get({
+    action: "getItemsLongRunningManual",
+    property: "itemsManual",
+    path: "/long-running",
+    onCancel: (state, payload) => {
+      console.info("manual cancellation", state, payload)
+    }
+  })
+  .get({
+    action: "getItemsLongRunningControlled",
+    property: "itemsControlled",
+    path: "/long-running",
+    onCancel: (state, payload) => {
+      console.info("controlled cancellation", state, payload)
+    }
+  })
+  .getStore()
+
+export default cancel

--- a/tests/src/stores/index.js
+++ b/tests/src/stores/index.js
@@ -2,8 +2,10 @@ import Vue from "vue"
 import Vuex from "vuex"
 
 import posts from "./posts"
+import cancel from "./cancel"
 
 Vue.use(Vuex)
+Vue.config.devtools = true
 
 export const state = {
   count: 0
@@ -19,7 +21,8 @@ const store = new Vuex.Store({
   state,
   mutations,
   modules: {
-    posts
+    posts,
+    cancel
   }
 })
 

--- a/tests/src/stores/posts.js
+++ b/tests/src/stores/posts.js
@@ -31,12 +31,12 @@ const posts = new Vapi({
     action: "getPost",
     property: "post",
     path: ({ id }) => `/posts/${id}`,
-    onSuccess(state, payload, axios, actionParams) {
+    onSuccess(state, payload, axios, requestConfig) {
       state.post = payload.data
-      console.log(actionParams)
+      console.log(requestConfig)
     },
-    onError(state, error, axios, actionParams) {
-      console.log(actionParams, error)
+    onError(state, error, axios, requestConfig) {
+      console.log(requestConfig, error)
     }
   })
   .get({


### PR DESCRIPTION
https://app.clubhouse.io/dashhudson/story/40137/allow-pass-through-of-axiosrequestconfig-in-vuex-rest-api-action-calls

### Changes

- Updated axios to latest version in library peer dependencies and in test project dependencies.
- Removed `ActionParams` from the project and allowed for pass through of `AxiosRequestConfig` objects instead. Luckily since these objects share property names, the change will be backwards compatible anywhere `actionParams` would have been used in callbacks.
- Added first class support for request cancellation, I will give some examples below (the test project is updated to demonstrate these, see `http://localhost:8080/#/cancel`).
- To follow up with the previous point, `onCancel` can be added to any action now which uses the same signature as `onSuccess` and `onError`.

### Request Cancellation

**Auto Cancellation:**

`autoCancel` can now be set in `ShorthandResourceActionOptions`. This cancels a previous / pending request for a given action and ignores handling the resulting cancellation error, effectively suspending the pending state. However, if a non-cancellation error occurs (say a user gets rate limited or the server crashes) the normal error handling flow will resume.

This is most useful when an action can lead to data races because of some hard to control user behavior or interaction. In our app, we see this often when filtering lists of objects, etc. This is much easier to reason about than trying to write boiler plate code to make sure a resulting payload is safe to set or merge into the store in `onSuccess`.

Code example:

```javascript
.get({
  autoCancel: true,
  action: "getItemsLongRunningAutoCancel",
  property: "itemsAuto",
  path: "/long-running"
})
```

Live example:

![auto-cancel](https://user-images.githubusercontent.com/14235978/113315153-5e2a6400-92e3-11eb-88be-d57b51a2e013.gif)

**Manual Cancellation:**

Added a `source` property to the action states so axios cancel sources can be easily referenced / mapped to components for situations where `autoCancel` isn't useful (say you want to let the user deliberately cancel something).

Code example:

_(see `tests/src/components/CancelTest.vue` in this pr for a more detailed example)_
```javascript
if (this.foo.source.bar) {
  this.foo.source.bar.cancel()
}
```

Live Example:

![manual-cancel](https://user-images.githubusercontent.com/14235978/113316400-ac8c3280-92e4-11eb-8560-6ab95259ee96.gif)

**Manual Cancellation - Controlled:**

Let's say you didn't want to use a cancel source set by the library for some reason, you can supply your own now that `AxiosRequestConfig` is being passed through. This is a good example of both changes made in this PR.

Code example:

_(see `tests/src/components/CancelTest.vue` in this pr for a more detailed example)_
```javascript
const CancelToken = axios.CancelToken
const source = CancelToken.source()

try {
  await doGetFoo({
    cancelToken: source.token
  })
} catch (e) {
  console.error(e)
}
```

### Notes

- I removed the check for `paramsSerializer` in `requestFn` [here](https://github.com/dashhudson/vuex-rest-api/pull/1/files#diff-4572c8f9a8afe4d84e3a2e05edd9e40e0493d54f9f5547e0c47b1b2fa23b45c8L89-L93). I don't really see a scenario where the default axios params serializer would be unset in the case that a custom one isn't. Seems more logical to just let that combo error out naturally if `queryParams` is enabled and a custom serializer is defined but misconfigured somehow.

### How to run the changes in dash-web locally

_Note: I will move these steps into a doc somewhere for future maintenance._

1. Clone this repo and `npm install`
2. Run `npx tsc --watch` or `npm build` to ensure the library can be built without errors (if you run into anything let me know).
3. Run `npm link` to setup a symlink (more info on how this works in npm docs if you're unfamiliar).
4. Navigate to the dash-web directory and run `npm link vuex-rest-api`, this will use the symlinked directory instead of a version pulled down from the npm registry. This should be all you need to do to play around!

Additionally there is a test app provided by the author in this repo under `tests/`. I added some example code there, you will just need to do the same as above (point 4) in that directory by running `npm link vuex-rest-api` and then run `npm run dev` to spin up the example site.