### PR TITLE
Fix regression in vuex-rest-api v2.13.0

### DIFF
--- a/dist/Resource.js
+++ b/dist/Resource.js
@@ -69,7 +69,7 @@ var Resource = /** @class */ (function () {
                 // this has the unintended side effect of setting content-type=application/json headers and is an unwanted
                 // side effect. This is the least intrusive way of handling this problem for now, but I don't think we really
                 // even need a default data prop in this flow.
-                if (method.toLowerCase() === 'get') {
+                if (["post", "put", "patch"].indexOf(method.toLowerCase()) === -1) {
                     delete fullRequestConfig.data;
                 }
                 return _this.axios.request(fullRequestConfig);

--- a/dist/Resource.js
+++ b/dist/Resource.js
@@ -59,11 +59,19 @@ var Resource = /** @class */ (function () {
                 }
                 // This assignment is made to respect the priority of the base URL, url, method.
                 // It is as following: baseURL > axios instance base URL > request config base URL
+                var method = options.method;
                 var fullRequestConfig = Object.assign({
-                    method: options.method,
+                    method: method,
                     url: urlFn(params),
                     baseURL: _this.normalizedBaseURL,
                 }, tmpRequestConfig);
+                // In v2.13.0 a regression was introduced that was allowing data to be passed along with GET requests,
+                // this has the unintended side effect of setting content-type=application/json headers and is an unwanted
+                // side effect. This is the least intrusive way of handling this problem for now, but I don't think we really
+                // even need a default data prop in this flow.
+                if (method.toLowerCase() === 'get') {
+                    delete fullRequestConfig.data;
+                }
                 return _this.axios.request(fullRequestConfig);
             },
             property: options.property,

--- a/dist/Resource.js
+++ b/dist/Resource.js
@@ -66,9 +66,9 @@ var Resource = /** @class */ (function () {
                     baseURL: _this.normalizedBaseURL,
                 }, tmpRequestConfig);
                 // In v2.13.0 a regression was introduced that was allowing data to be passed along with GET requests,
-                // this has the unintended side effect of setting content-type=application/json headers and is an unwanted
-                // side effect. This is the least intrusive way of handling this problem for now, but I don't think we really
-                // even need a default data prop in this flow.
+                // this has the unintended side effect of setting content-type: application/json;charset=UTF-8 headers and
+                // is an unwanted side effect. This is the least intrusive way of handling this problem for now, but I don't
+                // think we really even need a default data prop in this flow.
                 if (["post", "put", "patch"].indexOf(method.toLowerCase()) === -1) {
                     delete fullRequestConfig.data;
                 }

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -108,11 +108,20 @@ export class Resource {
 
         // This assignment is made to respect the priority of the base URL, url, method.
         // It is as following: baseURL > axios instance base URL > request config base URL
+        const method = options.method as AxiosRequestConfig["method"]
         const fullRequestConfig = Object.assign({
-          method: options.method as AxiosRequestConfig["method"],
+          method,
           url: urlFn(params),
           baseURL: this.normalizedBaseURL,
         }, tmpRequestConfig)
+
+        // In v2.13.0 a regression was introduced that was allowing data to be passed along with GET requests,
+        // this has the unintended side effect of setting content-type=application/json headers and is an unwanted
+        // side effect. This is the least intrusive way of handling this problem for now, but I don't think we really
+        // even need a default data prop in this flow.
+        if (method.toLowerCase() === 'get') {
+          delete fullRequestConfig.data;
+        }
         return this.axios.request(fullRequestConfig)
       },
       property: options.property,

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -119,7 +119,7 @@ export class Resource {
         // this has the unintended side effect of setting content-type=application/json headers and is an unwanted
         // side effect. This is the least intrusive way of handling this problem for now, but I don't think we really
         // even need a default data prop in this flow.
-        if (method.toLowerCase() === 'get') {
+        if (["post", "put", "patch"].indexOf(method.toLowerCase()) === -1) {
           delete fullRequestConfig.data;
         }
         return this.axios.request(fullRequestConfig)

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -116,9 +116,9 @@ export class Resource {
         }, tmpRequestConfig)
 
         // In v2.13.0 a regression was introduced that was allowing data to be passed along with GET requests,
-        // this has the unintended side effect of setting content-type=application/json headers and is an unwanted
-        // side effect. This is the least intrusive way of handling this problem for now, but I don't think we really
-        // even need a default data prop in this flow.
+        // this has the unintended side effect of setting content-type: application/json;charset=UTF-8 headers and
+        // is an unwanted side effect. This is the least intrusive way of handling this problem for now, but I don't
+        // think we really even need a default data prop in this flow.
         if (["post", "put", "patch"].indexOf(method.toLowerCase()) === -1) {
           delete fullRequestConfig.data;
         }


### PR DESCRIPTION
This PR fixes a regression introduced by vuex-rest-api v2.13.0. GET requests are having the `data` property included in `AxiosRequestConfig`, which causes axios to append a `content-type: application/json;charset=UTF-8` header. This is an unwanted side effect. In dash-web this breaks one of the media requests that doesn't expect this encoding type as example of the downstream effect.

I checked the vuex-rest-api changelog for sanity and this is the only breaking change between `2.10.0` (what dash-web prod is currently on) and `2.13.0` (although it was not explicitly marked as a breaking change, it seems like the author didn't bother testing based off the exchange in the PR for this but the bug isn't immediately obvious either).

You can see the change here: https://github.com/christianmalek/vuex-rest-api/pull/103/files